### PR TITLE
Remove fetchRegistry: false

### DIFF
--- a/microservice-demo/microservice-demo-turbine-server/src/main/resources/application.yml
+++ b/microservice-demo/microservice-demo-turbine-server/src/main/resources/application.yml
@@ -3,8 +3,6 @@ server:
 
 eureka:
   client:
-    registerWithEureka: true
-    fetchRegistry: false
     serviceUrl:
       defaultZone: http://eureka:8761/eureka/    
   server:


### PR DESCRIPTION
Effectively turns off eureka for using other registered services except for registering the running service