### PR TITLE
Let Zuul deliver Bootstrap webjar assets

### DIFF
--- a/microservice-demo/microservice-demo-catalog/pom.xml
+++ b/microservice-demo/microservice-demo-catalog/pom.xml
@@ -74,7 +74,6 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>bootstrap</artifactId>
-			<version>3.3.6</version>
 		</dependency>
 
 	</dependencies>

--- a/microservice-demo/microservice-demo-customer/pom.xml
+++ b/microservice-demo/microservice-demo-customer/pom.xml
@@ -74,7 +74,6 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>bootstrap</artifactId>
-			<version>3.3.6</version>
 		</dependency>
 
 	</dependencies>

--- a/microservice-demo/microservice-demo-order/pom.xml
+++ b/microservice-demo/microservice-demo-order/pom.xml
@@ -79,7 +79,6 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>bootstrap</artifactId>
-			<version>3.3.6</version>
 		</dependency>
 
 	</dependencies>

--- a/microservice-demo/microservice-demo-zuul-server/pom.xml
+++ b/microservice-demo/microservice-demo-zuul-server/pom.xml
@@ -29,6 +29,10 @@
 			<artifactId>spring-cloud-starter-zuul</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>bootstrap</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/microservice-demo/pom.xml
+++ b/microservice-demo/pom.xml
@@ -37,6 +37,11 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.webjars</groupId>
+				<artifactId>bootstrap</artifactId>
+				<version>3.3.6</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
Zuul doesn't rewrite link to assets inside of HTML. Because the micro services expect bootstrap to be delivered from `/webjars/**` Zuul needs to serve these assets by himself.