### PR TITLE
Modified Dockerfile to make java the root process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+.idea
+*.iml

--- a/microservice-demo/microservice-demo-order/Dockerfile
+++ b/microservice-demo/microservice-demo-order/Dockerfile
@@ -1,4 +1,12 @@
 FROM ewolff/docker-java
-ADD target/microservice-demo-order-0.0.1-SNAPSHOT.jar .
-CMD /usr/bin/java -Xmx400m -Xms400m -jar microservice-demo-order-0.0.1-SNAPSHOT.jar
 EXPOSE 8080
+WORKDIR /data
+RUN mkdir /data/logs
+ADD target/microservice-demo-order-0.0.1-SNAPSHOT.jar /data/microservice-demo-order.jar
+
+# add wrapper script
+ADD start.sh /data/start.sh
+RUN chmod 0755 /data/start.sh
+
+# start docker command
+ENTRYPOINT ["/bin/sh", "/data/start.sh"]

--- a/microservice-demo/microservice-demo-order/start.sh
+++ b/microservice-demo/microservice-demo-order/start.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# wrapper script for jvm startup
+# uses environment variables INSTANCE_NAME, EXTRA_JAVA_OPTS and ADDITIONAL_PARAMETERS for JVM start
+#
+# NOTE: This writes GC logs to /data/logs! Make sure to bind this folder to an external volume!
+$JAR_NAME=
+
+if [ -z "$PROFILE" ] ; then
+  export PROFILE="dev"
+  echo "No \$PROFILE variable found. Defaulting to profile ${PROFILE}"
+fi
+if [ -z "$JAR_NAME" ] ; then
+  export JAR_NAME="microservice-demo-order.jar"
+  echo "No \$JAR_NAME variable found. Defaulting to ${JAR_NAME}"
+fi
+
+if [ -z "$EXTRA_JAVA_OPTS" ] ; then
+    # NOTE: The gc log is intentionally named *.gc-log, so it is not logrotated by unix logrotate on the host
+    export EXTRA_JAVA_OPTS="-Xms128m -Xmx512m \
+        -Djava.security.egd=file:/dev/./urandom -Dlog4j.configurationFile=log4j2.xml
+        -Xloggc:/data/logs/microservice-$(date +%Y%m%d_%H%M).gc-log -XX:+UseGCLogFileRotation \
+        -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=50M\
+        -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/data/logs/ga-edge-heapdump-`date +%Y%m%d_%H%M`.hprof \
+        -XX:+PrintGCDateStamps -verbose:gc -XX:+PrintGCDetails \
+        -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime \
+        -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"
+  echo "No \$EXTRA_JAVA_OPTS variable found. Using default EXTRA_JAVA_OPTS=$EXTRA_JAVA_OPTS"
+fi
+
+MIN_JAVA_OPTS="-D${INSTANCE_NAME} -server -XX:+PrintCommandLineFlags -XX:+PrintFlagsFinal \
+-Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8"
+
+echo "\
+Starting ${JAR_NAME}..."
+exec /usr/bin/java -server ${MIN_JAVA_OPTS} ${EXTRA_JAVA_OPTS} -jar /data/${JAR_NAME} --spring.profiles.active=${PROFILE} ${ADDITIONAL_PARAMETERS}


### PR DESCRIPTION
I modified the Dockerfile to make sure that java is executed as the
root process within the docker container. The reason behind this is
beforehand java was running as a subprocess of the shell which meant
that the java process didn’t receive the kill signal when the docker
container was stopped. This could leave java processes as zombies.

Additionally I introduced a shell script which enables us to provide
additional configuration options via the following optional env variables:

- $JAR_NAME: In case you renamed your jar differently than “microservice-demo-order.jar”
- $EXTRA_JAVA_OPTS: use this variable to overwrite JVM parameters e.g. Heap or GC; leave empty to see get a print of the default values
- $ADDITIONAL_PARAMETERS: Any parameter from application.yaml you want to overwrite
- $PROFILE: The Spring environment profile to be activated. Default: “dev”
- $INSTANCE_NAME: shows up in the process list on linux and is available to your application as a `System.getProperty(“INSTANCE_NAME”)`