### PR TITLE
Fixed connection to the Hystrix Dashboard

### DIFF
--- a/microservice-demo/microservice-demo-turbine-server/src/main/resources/application.yml
+++ b/microservice-demo/microservice-demo-turbine-server/src/main/resources/application.yml
@@ -16,4 +16,8 @@ turbine:
     clusterConfig: ORDER
   appConfig: order
 
+hystrix:
+  dashboard:
+    proxy-stream-allow-list: "**"
+
   


### PR DESCRIPTION
This PR contains a small change in the configuration (`application.yml`) of the Hystrix Dashboard service that fixes the connection to the dashboard. I was running the app locally and noticed from the logs the that the service had blocked the host from initiating a connection to the dashboard.  After looking at different pages, the solution was to configure Hystrix as shown in the answer to this [post](https://stackoverflow.com/questions/59738969/unable-to-connect-to-command-metric-stream-in-hystrix-dashboard-issue). 

I rebuilt the service after changing the configuration and I was able to see streams in the Hystrix dashboard.